### PR TITLE
Updates the reset module with form resets

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,19 @@
           <div class="flex"></div>
         </div>
       </section>
+
+      <section class="mb-8">
+        <div class="container">
+          <div class="row p-1">
+            <h2 class="tn-1 cg-4 caps">Inputs</h2>
+          </div>
+
+          <div class="row">
+            <input type="checkbox">
+
+          </div>
+        </div>
+      </section>
   </main>
 </body>
 </html>

--- a/modules/reset.scss
+++ b/modules/reset.scss
@@ -1,7 +1,4 @@
-/* http://meyerweb.com/eric/tools/css/reset/
- * v2.0 | 20110126
- * License: none (public domain)
- */
+$reset-inputs: true !default;
 
 html,
 body,
@@ -88,6 +85,7 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
+  font-weight: normal;
   font-family: inherit;
   vertical-align: baseline;
 }
@@ -134,19 +132,18 @@ table {
   border-spacing: 0;
 }
 
-// Form Resets.
-input {
-  appearance: none;
-  -webkit-appearance: none;
-  border: none;
-  background: none;
-  box-shadow: none;
-}
-
-button {
-  appearance: none;
-  -webkit-appearance: none;
-  border: none;
-  background: none;
-  box-shadow: none;
+@if $reset-inputs {
+  // Form Resets.
+  // This allows us to define the styles ourselves – except
+  // for radios and checkboxes where it may be useful to have 
+  // the native elements.
+  textarea,
+  input:not([type='radio']):not([type='checkbox']),
+  button {
+    appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    background: none;
+    box-shadow: none;
+  }
 }


### PR DESCRIPTION
Addresses #21.
- Fixes issue where heading tags rendered bold from the default browser stylesheet.
- Resets the browser default styling of text inputs and buttons. This can be disabled with a boolean `$reset-inputs: false`.
